### PR TITLE
Increase es version

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 module.exports = {
     parserOptions: {
-        ecmaVersion: 2017,
+        ecmaVersion: 2018,
         sourceType: 'module',
     },
     extends: 'airbnb-base',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-ecubelabs",
-  "version": "13.0.0",
+  "version": "14.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-ecubelabs",
-  "version": "14.0.0",
+  "version": "14.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
2017은 공식적으로 Object Spread Operator를 지원하지 않기 때문에 최신 버전의 eslint를 사용한다면 문제가 발생할 수 있습니다.
