### PR TITLE
fix: do not prefer default export

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,20 @@ const {
 } = ch;
 ```
 
+## [do-not-prefer-default-export](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/prefer-default-export.md#importprefer-default-export)
+```
+// good1.js
+
+// There is a default export.
+export const foo = 'foo';
+const bar = 'bar';
+export default 'bar';
+```
+```
+// good2.js
+
+export const foo = 'foo';
+```
+[Airbnb JavaScript Style Guide](https://github.com/airbnb/javascript#modules--prefer-default-export) 는 default export 를 권고하고 있어서 그 규칙을 그대로 따랐지만 실제로 프로젝트에 적용해보니 모든 프로젝트에서 이 규칙을 예외처리하고 있어서 본 repo 에서도 규칙을 껐습니다.
+
 # };

--- a/index.js
+++ b/index.js
@@ -54,6 +54,7 @@ module.exports = {
                 argsIgnorePattern: '^_',
             },
         ],
+        'import/prefer-default-export': 'off',
     },
     plugins: ['import'],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-ecubelabs",
-  "version": "14.2.2",
+  "version": "14.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-ecubelabs",
-  "version": "14.2.2",
+  "version": "14.2.4",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/test/do-not-prefer-default-export.js
+++ b/test/do-not-prefer-default-export.js
@@ -1,0 +1,1 @@
+export const foo = 'foo';


### PR DESCRIPTION
[Airbnb JavaScript Style Guide](https://github.com/airbnb/javascript#modules--prefer-default-export) 는 default export 를 권고하고 있어서 그 규칙을 그대로 따랐지만 실제로 프로젝트에 적용해보니 모든 프로젝트에서 이 규칙을 예외처리하고 있어서 본 repo 에서도 규칙을 껐습니다.