### PR TITLE
fix: prettier/@typescript-eslint 사용 제거

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-config-ecubelabs",
-  "version": "15.2.0",
+  "version": "15.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-config-ecubelabs",
-      "version": "15.2.0",
+      "version": "15.2.1",
       "license": "MIT",
       "devDependencies": {
         "@ecubelabs/prettier-config": "0.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-ecubelabs",
-  "version": "15.2.0",
+  "version": "15.2.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/typescript.js
+++ b/typescript.js
@@ -1,5 +1,5 @@
 module.exports = {
-    extends: ['plugin:import/typescript', 'prettier/@typescript-eslint'],
+    extends: ['plugin:import/typescript'],
     parser: '@typescript-eslint/parser',
     plugins: ['@typescript-eslint'],
     rules: {


### PR DESCRIPTION
`prettier/@typescript-eslint` has been merged into `prettier` in `eslint-config-prettier 8.0.0`.
See: https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21